### PR TITLE
feat: improve performance of member?/2

### DIFF
--- a/benchmark/result_10.md
+++ b/benchmark/result_10.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2024-06-19 22:44:52.656750Z UTC
+Benchmark run from 2024-06-20 13:14:19.503582Z UTC
 
 ## System
 
@@ -64,29 +64,29 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.67 M</td>
-    <td style="white-space: nowrap; text-align: right">40.53 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5693.79%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">26.77 M</td>
+    <td style="white-space: nowrap; text-align: right">37.36 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8205.71%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.62 M</td>
-    <td style="white-space: nowrap; text-align: right">40.61 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8352.04%</td>
+    <td style="white-space: nowrap; text-align: right">25.51 M</td>
+    <td style="white-space: nowrap; text-align: right">39.20 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5467.06%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.73 M</td>
-    <td style="white-space: nowrap; text-align: right">53.40 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;12443.37%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.21 M</td>
+    <td style="white-space: nowrap; text-align: right">41.30 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8253.96%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
@@ -101,21 +101,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">24.67 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">26.77 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.62 M</td>
-    <td style="white-space: nowrap; text-align: right">1.0x</td>
+    <td style="white-space: nowrap; text-align: right">25.51 M</td>
+    <td style="white-space: nowrap; text-align: right">1.05x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.73 M</td>
-    <td style="white-space: nowrap; text-align: right">1.32x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.21 M</td>
+    <td style="white-space: nowrap; text-align: right">1.11x</td>
   </tr>
 
 </table>
@@ -131,7 +131,7 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
@@ -141,7 +141,7 @@ Memory Usage
     <td>1.0x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -158,7 +158,7 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
@@ -168,9 +168,9 @@ Reduction Count
     <td>1.33x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
 </table>
 
@@ -191,29 +191,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.66 M</td>
-    <td style="white-space: nowrap; text-align: right">40.56 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6708.60%</td>
+    <td style="white-space: nowrap; text-align: right">26.25 M</td>
+    <td style="white-space: nowrap; text-align: right">38.10 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5230.36%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.29 M</td>
-    <td style="white-space: nowrap; text-align: right">41.17 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5706.81%</td>
+    <td style="white-space: nowrap; text-align: right">24.48 M</td>
+    <td style="white-space: nowrap; text-align: right">40.84 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6721.88%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.68 M</td>
-    <td style="white-space: nowrap; text-align: right">53.53 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;10988.05%</td>
+    <td style="white-space: nowrap; text-align: right">22.92 M</td>
+    <td style="white-space: nowrap; text-align: right">43.62 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;44100.87%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
 </table>
@@ -228,20 +228,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">24.66 M</td>
+    <td style="white-space: nowrap;text-align: right">26.25 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.29 M</td>
-    <td style="white-space: nowrap; text-align: right">1.02x</td>
+    <td style="white-space: nowrap; text-align: right">24.48 M</td>
+    <td style="white-space: nowrap; text-align: right">1.07x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.68 M</td>
-    <td style="white-space: nowrap; text-align: right">1.32x</td>
+    <td style="white-space: nowrap; text-align: right">22.92 M</td>
+    <td style="white-space: nowrap; text-align: right">1.14x</td>
   </tr>
 
 </table>
@@ -295,8 +295,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.25x</td>
+    <td style="white-space: nowrap">3</td>
+    <td>0.75x</td>
   </tr>
 </table>
 
@@ -317,153 +317,27 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.10 M</td>
-    <td style="white-space: nowrap; text-align: right">41.49 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7834.17%</td>
+    <td style="white-space: nowrap; text-align: right">24.85 M</td>
+    <td style="white-space: nowrap; text-align: right">40.24 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7288.08%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">23.46 M</td>
-    <td style="white-space: nowrap; text-align: right">42.62 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7652.89%</td>
+    <td style="white-space: nowrap; text-align: right">24.78 M</td>
+    <td style="white-space: nowrap; text-align: right">40.35 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5025.02%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.59 M</td>
-    <td style="white-space: nowrap; text-align: right">73.60 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;10697.95%</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-    <td style="white-space: nowrap; text-align: right">90 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">24.10 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">23.46 M</td>
-    <td style="white-space: nowrap; text-align: right">1.03x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.59 M</td>
-    <td style="white-space: nowrap; text-align: right">1.77x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
-    <td>1.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">12</td>
-    <td>4.0x</td>
-  </tr>
-</table>
-
-
-__Input: 050%__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.56 M</td>
-    <td style="white-space: nowrap; text-align: right">40.71 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7886.03%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">22.58 M</td>
-    <td style="white-space: nowrap; text-align: right">44.28 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5173.64%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.51 M</td>
-    <td style="white-space: nowrap; text-align: right">60.59 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;12058.99%</td>
+    <td style="white-space: nowrap; text-align: right">19.21 M</td>
+    <td style="white-space: nowrap; text-align: right">52.05 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4985.54%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
@@ -480,523 +354,19 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">24.56 M</td>
+    <td style="white-space: nowrap;text-align: right">24.85 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">22.58 M</td>
-    <td style="white-space: nowrap; text-align: right">1.09x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.51 M</td>
-    <td style="white-space: nowrap; text-align: right">1.49x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
-    <td>1.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">9</td>
-    <td>3.0x</td>
-  </tr>
-</table>
-
-
-__Input: 075%__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">25.19 M</td>
-    <td style="white-space: nowrap; text-align: right">39.70 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8337.62%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">21.77 M</td>
-    <td style="white-space: nowrap; text-align: right">45.94 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;4980.92%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.73 M</td>
-    <td style="white-space: nowrap; text-align: right">72.82 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9311.64%</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-    <td style="white-space: nowrap; text-align: right">90 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">25.19 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">21.77 M</td>
-    <td style="white-space: nowrap; text-align: right">1.16x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.73 M</td>
-    <td style="white-space: nowrap; text-align: right">1.83x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
-    <td>1.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">12</td>
-    <td>4.0x</td>
-  </tr>
-</table>
-
-
-__Input: 090%__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">24.63 M</td>
-    <td style="white-space: nowrap; text-align: right">40.60 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8442.34%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.51 M</td>
-    <td style="white-space: nowrap; text-align: right">40.80 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5398.46%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.87 M</td>
-    <td style="white-space: nowrap; text-align: right">50.33 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;10179.20%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">24.63 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.51 M</td>
+    <td style="white-space: nowrap; text-align: right">24.78 M</td>
     <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.87 M</td>
-    <td style="white-space: nowrap; text-align: right">1.24x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
-    <td>1.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
-  </tr>
-</table>
-
-
-__Input: 100%__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">25.82 M</td>
-    <td style="white-space: nowrap; text-align: right">38.74 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9599.56%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.34 M</td>
-    <td style="white-space: nowrap; text-align: right">49.16 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6454.94%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.49 M</td>
-    <td style="white-space: nowrap; text-align: right">54.07 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;20239.99%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">25.82 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.34 M</td>
-    <td style="white-space: nowrap; text-align: right">1.27x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.49 M</td>
-    <td style="white-space: nowrap; text-align: right">1.4x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
-    <td>1.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
-  </tr>
-</table>
-
-
-__Input: higher__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">23.88 M</td>
-    <td style="white-space: nowrap; text-align: right">41.87 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7821.44%</td>
-    <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.48 M</td>
-    <td style="white-space: nowrap; text-align: right">48.83 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7157.53%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.53 M</td>
-    <td style="white-space: nowrap; text-align: right">53.97 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;18560.39%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">23.88 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.48 M</td>
-    <td style="white-space: nowrap; text-align: right">1.17x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.53 M</td>
+    <td style="white-space: nowrap; text-align: right">19.21 M</td>
     <td style="white-space: nowrap; text-align: right">1.29x</td>
   </tr>
 
@@ -1051,13 +421,13 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
   </tr>
 </table>
 
 
-__Input: lower__
+__Input: 050%__
 
 Run Time
 
@@ -1073,27 +443,27 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">23.74 M</td>
-    <td style="white-space: nowrap; text-align: right">42.12 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7821.87%</td>
+    <td style="white-space: nowrap; text-align: right">25.25 M</td>
+    <td style="white-space: nowrap; text-align: right">39.61 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7119.87%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.64 M</td>
-    <td style="white-space: nowrap; text-align: right">48.46 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5373.08%</td>
+    <td style="white-space: nowrap; text-align: right">23.14 M</td>
+    <td style="white-space: nowrap; text-align: right">43.22 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5594.96%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.15 M</td>
-    <td style="white-space: nowrap; text-align: right">55.10 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;20333.14%</td>
+    <td style="white-space: nowrap; text-align: right">20.88 M</td>
+    <td style="white-space: nowrap; text-align: right">47.88 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7791.19%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
@@ -1110,20 +480,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">23.74 M</td>
+    <td style="white-space: nowrap;text-align: right">25.25 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.64 M</td>
-    <td style="white-space: nowrap; text-align: right">1.15x</td>
+    <td style="white-space: nowrap; text-align: right">23.14 M</td>
+    <td style="white-space: nowrap; text-align: right">1.09x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.15 M</td>
-    <td style="white-space: nowrap; text-align: right">1.31x</td>
+    <td style="white-space: nowrap; text-align: right">20.88 M</td>
+    <td style="white-space: nowrap; text-align: right">1.21x</td>
   </tr>
 
 </table>
@@ -1177,7 +547,637 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+__Input: 075%__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">25.40 M</td>
+    <td style="white-space: nowrap; text-align: right">39.36 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5496.73%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.13 M</td>
+    <td style="white-space: nowrap; text-align: right">45.18 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5543.32%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">18.20 M</td>
+    <td style="white-space: nowrap; text-align: right">54.94 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;33714.00%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">70 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap;text-align: right">25.40 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.13 M</td>
+    <td style="white-space: nowrap; text-align: right">1.15x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">18.20 M</td>
+    <td style="white-space: nowrap; text-align: right">1.4x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+</table>
+
+
+__Input: 090%__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">26.36 M</td>
+    <td style="white-space: nowrap; text-align: right">37.93 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6308.21%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.40 M</td>
+    <td style="white-space: nowrap; text-align: right">40.99 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8695.40%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">23.73 M</td>
+    <td style="white-space: nowrap; text-align: right">42.14 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;44002.61%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap;text-align: right">26.36 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.40 M</td>
+    <td style="white-space: nowrap; text-align: right">1.08x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">23.73 M</td>
+    <td style="white-space: nowrap; text-align: right">1.11x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>0.75x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>0.75x</td>
+  </tr>
+</table>
+
+
+__Input: 100%__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">25.82 M</td>
+    <td style="white-space: nowrap; text-align: right">38.72 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6438.81%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.81 M</td>
+    <td style="white-space: nowrap; text-align: right">43.83 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;41320.16%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.53 M</td>
+    <td style="white-space: nowrap; text-align: right">46.46 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6450.25%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap;text-align: right">25.82 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.81 M</td>
+    <td style="white-space: nowrap; text-align: right">1.13x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.53 M</td>
+    <td style="white-space: nowrap; text-align: right">1.2x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+</table>
+
+
+__Input: higher__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">26.10 M</td>
+    <td style="white-space: nowrap; text-align: right">38.32 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7546.92%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.37 M</td>
+    <td style="white-space: nowrap; text-align: right">46.79 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6470.24%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.08 M</td>
+    <td style="white-space: nowrap; text-align: right">47.43 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;42453.66%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap;text-align: right">26.10 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.37 M</td>
+    <td style="white-space: nowrap; text-align: right">1.22x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.08 M</td>
+    <td style="white-space: nowrap; text-align: right">1.24x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+__Input: lower__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">24.57 M</td>
+    <td style="white-space: nowrap; text-align: right">40.70 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8610.60%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.23 M</td>
+    <td style="white-space: nowrap; text-align: right">41.26 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8712.54%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">20.50 M</td>
+    <td style="white-space: nowrap; text-align: right">48.79 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7434.05%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">24.57 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">24.23 M</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">20.50 M</td>
+    <td style="white-space: nowrap; text-align: right">1.2x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
   </tr>
 </table>

--- a/benchmark/result_100.md
+++ b/benchmark/result_100.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2024-06-19 22:52:37.731708Z UTC
+Benchmark run from 2024-06-20 13:21:55.914654Z UTC
 
 ## System
 
@@ -65,28 +65,28 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">23.84 M</td>
-    <td style="white-space: nowrap; text-align: right">41.95 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;20207.88%</td>
+    <td style="white-space: nowrap; text-align: right">24.28 M</td>
+    <td style="white-space: nowrap; text-align: right">41.18 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;19241.29%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.60 M</td>
+    <td style="white-space: nowrap; text-align: right">44.25 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;43623.78%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.11 M</td>
-    <td style="white-space: nowrap; text-align: right">47.36 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7268.74%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.09 M</td>
-    <td style="white-space: nowrap; text-align: right">52.40 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;15382.13%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">21.16 M</td>
+    <td style="white-space: nowrap; text-align: right">47.26 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;14641.88%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
@@ -102,20 +102,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">23.84 M</td>
+    <td style="white-space: nowrap;text-align: right">24.28 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.11 M</td>
-    <td style="white-space: nowrap; text-align: right">1.13x</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">22.60 M</td>
+    <td style="white-space: nowrap; text-align: right">1.07x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.09 M</td>
-    <td style="white-space: nowrap; text-align: right">1.25x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.16 M</td>
+    <td style="white-space: nowrap; text-align: right">1.15x</td>
   </tr>
 
 </table>
@@ -136,12 +136,12 @@ Memory Usage
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -163,14 +163,14 @@ Reduction Count
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>0.75x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.25x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>0.75x</td>
   </tr>
 </table>
 
@@ -191,29 +191,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.96 M</td>
-    <td style="white-space: nowrap; text-align: right">50.09 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;15488.59%</td>
+    <td style="white-space: nowrap; text-align: right">20.72 M</td>
+    <td style="white-space: nowrap; text-align: right">48.26 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;16131.31%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.80 M</td>
-    <td style="white-space: nowrap; text-align: right">50.50 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7061.51%</td>
+    <td style="white-space: nowrap; text-align: right">20.28 M</td>
+    <td style="white-space: nowrap; text-align: right">49.30 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;15231.82%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">9.79 M</td>
-    <td style="white-space: nowrap; text-align: right">102.12 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7124.88%</td>
-    <td style="white-space: nowrap; text-align: right">90 ns</td>
-    <td style="white-space: nowrap; text-align: right">130 ns</td>
+    <td style="white-space: nowrap; text-align: right">13.35 M</td>
+    <td style="white-space: nowrap; text-align: right">74.91 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;27649.31%</td>
+    <td style="white-space: nowrap; text-align: right">70 ns</td>
+    <td style="white-space: nowrap; text-align: right">100 ns</td>
   </tr>
 
 </table>
@@ -228,20 +228,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">19.96 M</td>
+    <td style="white-space: nowrap;text-align: right">20.72 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.80 M</td>
-    <td style="white-space: nowrap; text-align: right">1.01x</td>
+    <td style="white-space: nowrap; text-align: right">20.28 M</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">9.79 M</td>
-    <td style="white-space: nowrap; text-align: right">2.04x</td>
+    <td style="white-space: nowrap; text-align: right">13.35 M</td>
+    <td style="white-space: nowrap; text-align: right">1.55x</td>
   </tr>
 
 </table>
@@ -295,8 +295,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">21</td>
-    <td>5.25x</td>
+    <td style="white-space: nowrap">7</td>
+    <td>1.75x</td>
   </tr>
 </table>
 
@@ -317,29 +317,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.02 M</td>
-    <td style="white-space: nowrap; text-align: right">47.58 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7355.19%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">20.90 M</td>
+    <td style="white-space: nowrap; text-align: right">47.86 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;15651.89%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.28 M</td>
-    <td style="white-space: nowrap; text-align: right">61.44 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;14744.64%</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-    <td style="white-space: nowrap; text-align: right">80 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.93 M</td>
-    <td style="white-space: nowrap; text-align: right">71.80 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8479.28%</td>
+    <td style="white-space: nowrap; text-align: right">17.25 M</td>
+    <td style="white-space: nowrap; text-align: right">57.97 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;34712.52%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
-    <td style="white-space: nowrap; text-align: right">90 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">16.25 M</td>
+    <td style="white-space: nowrap; text-align: right">61.52 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;13284.45%</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+    <td style="white-space: nowrap; text-align: right">80 ns</td>
   </tr>
 
 </table>
@@ -354,20 +354,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.02 M</td>
+    <td style="white-space: nowrap;text-align: right">20.90 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.28 M</td>
-    <td style="white-space: nowrap; text-align: right">1.29x</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">17.25 M</td>
+    <td style="white-space: nowrap; text-align: right">1.21x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.93 M</td>
-    <td style="white-space: nowrap; text-align: right">1.51x</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">16.25 M</td>
+    <td style="white-space: nowrap; text-align: right">1.29x</td>
   </tr>
 
 </table>
@@ -388,12 +388,12 @@ Memory Usage
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -415,14 +415,14 @@ Reduction Count
     <td>&nbsp;</td>
   </tr>
     <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+    <tr>
     <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">5</td>
     <td>1.67x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">12</td>
-    <td>4.0x</td>
   </tr>
 </table>
 
@@ -443,27 +443,27 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.83 M</td>
-    <td style="white-space: nowrap; text-align: right">50.44 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6780.40%</td>
+    <td style="white-space: nowrap; text-align: right">19.97 M</td>
+    <td style="white-space: nowrap; text-align: right">50.08 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;19299.39%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.84 M</td>
-    <td style="white-space: nowrap; text-align: right">59.37 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9392.61%</td>
+    <td style="white-space: nowrap; text-align: right">19.01 M</td>
+    <td style="white-space: nowrap; text-align: right">52.59 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;36900.85%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">11.65 M</td>
-    <td style="white-space: nowrap; text-align: right">85.87 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;11183.68%</td>
+    <td style="white-space: nowrap; text-align: right">11.56 M</td>
+    <td style="white-space: nowrap; text-align: right">86.53 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;9532.19%</td>
     <td style="white-space: nowrap; text-align: right">80 ns</td>
     <td style="white-space: nowrap; text-align: right">110 ns</td>
   </tr>
@@ -480,20 +480,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.83 M</td>
+    <td style="white-space: nowrap;text-align: right">19.97 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">16.84 M</td>
-    <td style="white-space: nowrap; text-align: right">1.18x</td>
+    <td style="white-space: nowrap; text-align: right">19.01 M</td>
+    <td style="white-space: nowrap; text-align: right">1.05x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">11.65 M</td>
-    <td style="white-space: nowrap; text-align: right">1.7x</td>
+    <td style="white-space: nowrap; text-align: right">11.56 M</td>
+    <td style="white-space: nowrap; text-align: right">1.73x</td>
   </tr>
 
 </table>
@@ -542,8 +542,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">9</td>
-    <td>3.0x</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -569,28 +569,28 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.07 M</td>
-    <td style="white-space: nowrap; text-align: right">47.46 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7501.49%</td>
+    <td style="white-space: nowrap; text-align: right">20.54 M</td>
+    <td style="white-space: nowrap; text-align: right">48.68 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;17684.56%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.63 M</td>
-    <td style="white-space: nowrap; text-align: right">115.92 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6894.04%</td>
-    <td style="white-space: nowrap; text-align: right">110 ns</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
+    <td style="white-space: nowrap; text-align: right">13.65 M</td>
+    <td style="white-space: nowrap; text-align: right">73.27 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;3678.45%</td>
+    <td style="white-space: nowrap; text-align: right">70 ns</td>
+    <td style="white-space: nowrap; text-align: right">100 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.26 M</td>
-    <td style="white-space: nowrap; text-align: right">121.08 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7491.92%</td>
-    <td style="white-space: nowrap; text-align: right">120 ns</td>
+    <td style="white-space: nowrap; text-align: right">8.43 M</td>
+    <td style="white-space: nowrap; text-align: right">118.58 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7405.24%</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
     <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
@@ -606,20 +606,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.07 M</td>
+    <td style="white-space: nowrap;text-align: right">20.54 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.63 M</td>
-    <td style="white-space: nowrap; text-align: right">2.44x</td>
+    <td style="white-space: nowrap; text-align: right">13.65 M</td>
+    <td style="white-space: nowrap; text-align: right">1.51x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.26 M</td>
-    <td style="white-space: nowrap; text-align: right">2.55x</td>
+    <td style="white-space: nowrap; text-align: right">8.43 M</td>
+    <td style="white-space: nowrap; text-align: right">2.44x</td>
   </tr>
 
 </table>
@@ -668,8 +668,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">24</td>
-    <td>8.0x</td>
+    <td style="white-space: nowrap">8</td>
+    <td>2.67x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -695,29 +695,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.49 M</td>
-    <td style="white-space: nowrap; text-align: right">46.54 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7393.24%</td>
+    <td style="white-space: nowrap; text-align: right">20.83 M</td>
+    <td style="white-space: nowrap; text-align: right">48.00 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;14854.20%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.89 M</td>
-    <td style="white-space: nowrap; text-align: right">112.47 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5819.52%</td>
+    <td style="white-space: nowrap; text-align: right">13.08 M</td>
+    <td style="white-space: nowrap; text-align: right">76.44 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;25713.73%</td>
+    <td style="white-space: nowrap; text-align: right">70 ns</td>
     <td style="white-space: nowrap; text-align: right">100 ns</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">7.90 M</td>
-    <td style="white-space: nowrap; text-align: right">126.63 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7742.34%</td>
+    <td style="white-space: nowrap; text-align: right">8.21 M</td>
+    <td style="white-space: nowrap; text-align: right">121.73 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7395.59%</td>
     <td style="white-space: nowrap; text-align: right">120 ns</td>
-    <td style="white-space: nowrap; text-align: right">160 ns</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
 </table>
@@ -732,20 +732,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.49 M</td>
+    <td style="white-space: nowrap;text-align: right">20.83 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">8.89 M</td>
-    <td style="white-space: nowrap; text-align: right">2.42x</td>
+    <td style="white-space: nowrap; text-align: right">13.08 M</td>
+    <td style="white-space: nowrap; text-align: right">1.59x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">7.90 M</td>
-    <td style="white-space: nowrap; text-align: right">2.72x</td>
+    <td style="white-space: nowrap; text-align: right">8.21 M</td>
+    <td style="white-space: nowrap; text-align: right">2.54x</td>
   </tr>
 
 </table>
@@ -794,8 +794,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">24</td>
-    <td>8.0x</td>
+    <td style="white-space: nowrap">8</td>
+    <td>2.67x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -820,29 +820,29 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.97 M</td>
-    <td style="white-space: nowrap; text-align: right">47.68 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7354.13%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">24.13 M</td>
+    <td style="white-space: nowrap; text-align: right">41.44 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;9259.27%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.37 M</td>
-    <td style="white-space: nowrap; text-align: right">57.57 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;37050.00%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.83 M</td>
+    <td style="white-space: nowrap; text-align: right">48.00 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;14722.24%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.77 M</td>
-    <td style="white-space: nowrap; text-align: right">147.71 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7028.56%</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
+    <td style="white-space: nowrap; text-align: right">6.54 M</td>
+    <td style="white-space: nowrap; text-align: right">152.85 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6132.10%</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
     <td style="white-space: nowrap; text-align: right">190 ns</td>
   </tr>
 
@@ -857,21 +857,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.97 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">24.13 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.37 M</td>
-    <td style="white-space: nowrap; text-align: right">1.21x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.83 M</td>
+    <td style="white-space: nowrap; text-align: right">1.16x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.77 M</td>
-    <td style="white-space: nowrap; text-align: right">3.1x</td>
+    <td style="white-space: nowrap; text-align: right">6.54 M</td>
+    <td style="white-space: nowrap; text-align: right">3.69x</td>
   </tr>
 
 </table>
@@ -887,12 +887,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -914,14 +914,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -947,27 +947,27 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">22.45 M</td>
-    <td style="white-space: nowrap; text-align: right">44.54 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5966.84%</td>
+    <td style="white-space: nowrap; text-align: right">22.05 M</td>
+    <td style="white-space: nowrap; text-align: right">45.34 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;19768.49%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.44 M</td>
-    <td style="white-space: nowrap; text-align: right">57.33 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;36770.44%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">21.91 M</td>
+    <td style="white-space: nowrap; text-align: right">45.64 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;43171.28%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.78 M</td>
-    <td style="white-space: nowrap; text-align: right">147.47 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7169.53%</td>
+    <td style="white-space: nowrap; text-align: right">6.80 M</td>
+    <td style="white-space: nowrap; text-align: right">147.10 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5903.56%</td>
     <td style="white-space: nowrap; text-align: right">140 ns</td>
     <td style="white-space: nowrap; text-align: right">190 ns</td>
   </tr>
@@ -984,20 +984,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">22.45 M</td>
+    <td style="white-space: nowrap;text-align: right">22.05 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.44 M</td>
-    <td style="white-space: nowrap; text-align: right">1.29x</td>
+    <td style="white-space: nowrap; text-align: right">21.91 M</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.78 M</td>
-    <td style="white-space: nowrap; text-align: right">3.31x</td>
+    <td style="white-space: nowrap; text-align: right">6.80 M</td>
+    <td style="white-space: nowrap; text-align: right">3.24x</td>
   </tr>
 
 </table>
@@ -1046,8 +1046,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -1072,28 +1072,28 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">23.17 M</td>
+    <td style="white-space: nowrap; text-align: right">43.17 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;43184.61%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.49 M</td>
-    <td style="white-space: nowrap; text-align: right">46.53 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7530.27%</td>
+    <td style="white-space: nowrap; text-align: right">21.54 M</td>
+    <td style="white-space: nowrap; text-align: right">46.43 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;16517.16%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.90 M</td>
-    <td style="white-space: nowrap; text-align: right">52.91 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16149.98%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.44 M</td>
-    <td style="white-space: nowrap; text-align: right">155.22 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6048.46%</td>
+    <td style="white-space: nowrap; text-align: right">6.48 M</td>
+    <td style="white-space: nowrap; text-align: right">154.33 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6106.94%</td>
     <td style="white-space: nowrap; text-align: right">150 ns</td>
     <td style="white-space: nowrap; text-align: right">190 ns</td>
   </tr>
@@ -1109,21 +1109,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.49 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">23.17 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.90 M</td>
-    <td style="white-space: nowrap; text-align: right">1.14x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.54 M</td>
+    <td style="white-space: nowrap; text-align: right">1.08x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.44 M</td>
-    <td style="white-space: nowrap; text-align: right">3.34x</td>
+    <td style="white-space: nowrap; text-align: right">6.48 M</td>
+    <td style="white-space: nowrap; text-align: right">3.58x</td>
   </tr>
 
 </table>
@@ -1139,12 +1139,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1166,14 +1166,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>

--- a/benchmark/result_1000.md
+++ b/benchmark/result_1000.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2024-06-19 22:59:43.604800Z UTC
+Benchmark run from 2024-06-20 13:28:53.976552Z UTC
 
 ## System
 
@@ -64,28 +64,28 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.68 M</td>
-    <td style="white-space: nowrap; text-align: right">40.52 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;810.22%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.82 M</td>
+    <td style="white-space: nowrap; text-align: right">38.72 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2208.82%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.82 M</td>
+    <td style="white-space: nowrap; text-align: right">38.73 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;612.85%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.05 M</td>
-    <td style="white-space: nowrap; text-align: right">47.51 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5061.69%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.02 M</td>
-    <td style="white-space: nowrap; text-align: right">49.95 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6175.73%</td>
+    <td style="white-space: nowrap; text-align: right">21.14 M</td>
+    <td style="white-space: nowrap; text-align: right">47.31 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6367.61%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
@@ -101,21 +101,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">24.68 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.82 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.05 M</td>
-    <td style="white-space: nowrap; text-align: right">1.17x</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.82 M</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.02 M</td>
-    <td style="white-space: nowrap; text-align: right">1.23x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.14 M</td>
+    <td style="white-space: nowrap; text-align: right">1.22x</td>
   </tr>
 
 </table>
@@ -131,17 +131,17 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -158,19 +158,19 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
     <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">4</td>
-    <td>&nbsp;</td>
+    <td>1.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">3</td>
-    <td>0.75x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.25x</td>
+    <td>1.0x</td>
   </tr>
 </table>
 
@@ -191,29 +191,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.50 M</td>
-    <td style="white-space: nowrap; text-align: right">48.79 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6954.28%</td>
+    <td style="white-space: nowrap; text-align: right">21.20 M</td>
+    <td style="white-space: nowrap; text-align: right">47.17 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6847.91%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">7.02 M</td>
-    <td style="white-space: nowrap; text-align: right">142.52 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;281.50%</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
-    <td style="white-space: nowrap; text-align: right">180 ns</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">11.28 M</td>
+    <td style="white-space: nowrap; text-align: right">88.67 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1179.35%</td>
+    <td style="white-space: nowrap; text-align: right">90 ns</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.33 M</td>
-    <td style="white-space: nowrap; text-align: right">158.06 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9968.44%</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">7.23 M</td>
+    <td style="white-space: nowrap; text-align: right">138.31 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;207.77%</td>
     <td style="white-space: nowrap; text-align: right">140 ns</td>
-    <td style="white-space: nowrap; text-align: right">200 ns</td>
+    <td style="white-space: nowrap; text-align: right">170 ns</td>
   </tr>
 
 </table>
@@ -228,146 +228,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.50 M</td>
-    <td>&nbsp;</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">7.02 M</td>
-    <td style="white-space: nowrap; text-align: right">2.92x</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.33 M</td>
-    <td style="white-space: nowrap; text-align: right">3.24x</td>
-  </tr>
-
-</table>
-
-
-
-Memory Usage
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">0 B</td>
-    <td>1.0x</td>
-  </tr>
-</table>
-
-
-
-Reduction Count
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Factor</th>
-  </tr>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap">3</td>
-    <td>&nbsp;</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">10</td>
-    <td>3.33x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">36</td>
-    <td>12.0x</td>
-  </tr>
-</table>
-
-
-__Input: 025%__
-
-Run Time
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Average</th>
-    <th style="text-align: right">Devitation</th>
-    <th style="text-align: right">Median</th>
-    <th style="text-align: right">99th&nbsp;%</th>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.52 M</td>
-    <td style="white-space: nowrap; text-align: right">48.73 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6809.94%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">12.34 M</td>
-    <td style="white-space: nowrap; text-align: right">81.01 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;30462.13%</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-    <td style="white-space: nowrap; text-align: right">100 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">3.44 M</td>
-    <td style="white-space: nowrap; text-align: right">290.33 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;116.39%</td>
-    <td style="white-space: nowrap; text-align: right">280 ns</td>
-    <td style="white-space: nowrap; text-align: right">380 ns</td>
-  </tr>
-
-</table>
-
-
-Run Time Comparison
-
-<table style="width: 1%">
-  <tr>
-    <th>Name</th>
-    <th style="text-align: right">IPS</th>
-    <th style="text-align: right">Slower</th>
-  <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.52 M</td>
+    <td style="white-space: nowrap;text-align: right">21.20 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">12.34 M</td>
-    <td style="white-space: nowrap; text-align: right">1.66x</td>
+    <td style="white-space: nowrap; text-align: right">11.28 M</td>
+    <td style="white-space: nowrap; text-align: right">1.88x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">3.44 M</td>
-    <td style="white-space: nowrap; text-align: right">5.96x</td>
+    <td style="white-space: nowrap; text-align: right">7.23 M</td>
+    <td style="white-space: nowrap; text-align: right">2.93x</td>
   </tr>
 
 </table>
@@ -421,13 +295,13 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">19</td>
-    <td>6.33x</td>
+    <td style="white-space: nowrap">10</td>
+    <td>3.33x</td>
   </tr>
 </table>
 
 
-__Input: 050%__
+__Input: 025%__
 
 Run Time
 
@@ -443,29 +317,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.07 M</td>
-    <td style="white-space: nowrap; text-align: right">47.46 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5367.56%</td>
+    <td style="white-space: nowrap; text-align: right">21.26 M</td>
+    <td style="white-space: nowrap; text-align: right">47.03 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4456.54%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">14.73 M</td>
-    <td style="white-space: nowrap; text-align: right">67.88 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;37297.75%</td>
+    <td style="white-space: nowrap; text-align: right">19.17 M</td>
+    <td style="white-space: nowrap; text-align: right">52.18 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1892.01%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.99 M</td>
-    <td style="white-space: nowrap; text-align: right">501.48 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;122.44%</td>
-    <td style="white-space: nowrap; text-align: right">500 ns</td>
-    <td style="white-space: nowrap; text-align: right">620 ns</td>
+    <td style="white-space: nowrap; text-align: right">3.69 M</td>
+    <td style="white-space: nowrap; text-align: right">270.80 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;129.66%</td>
+    <td style="white-space: nowrap; text-align: right">270 ns</td>
+    <td style="white-space: nowrap; text-align: right">340 ns</td>
   </tr>
 
 </table>
@@ -480,20 +354,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.07 M</td>
+    <td style="white-space: nowrap;text-align: right">21.26 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">14.73 M</td>
-    <td style="white-space: nowrap; text-align: right">1.43x</td>
+    <td style="white-space: nowrap; text-align: right">19.17 M</td>
+    <td style="white-space: nowrap; text-align: right">1.11x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.99 M</td>
-    <td style="white-space: nowrap; text-align: right">10.57x</td>
+    <td style="white-space: nowrap; text-align: right">3.69 M</td>
+    <td style="white-space: nowrap; text-align: right">5.76x</td>
   </tr>
 
 </table>
@@ -542,8 +416,134 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">9</td>
-    <td>3.0x</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">19</td>
+    <td>6.33x</td>
+  </tr>
+</table>
+
+
+__Input: 050%__
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.26 M</td>
+    <td style="white-space: nowrap; text-align: right">47.04 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6363.70%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.19 M</td>
+    <td style="white-space: nowrap; text-align: right">47.20 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1879.63%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">2.01 M</td>
+    <td style="white-space: nowrap; text-align: right">497.55 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;110.47%</td>
+    <td style="white-space: nowrap; text-align: right">490 ns</td>
+    <td style="white-space: nowrap; text-align: right">620 ns</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap;text-align: right">21.26 M</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.19 M</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">2.01 M</td>
+    <td style="white-space: nowrap; text-align: right">10.58x</td>
+  </tr>
+
+</table>
+
+
+
+Memory Usage
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">0 B</td>
+    <td>1.0x</td>
+  </tr>
+</table>
+
+
+
+Reduction Count
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Factor</th>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -569,29 +569,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.80 M</td>
-    <td style="white-space: nowrap; text-align: right">48.08 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;4924.04%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">21.84 M</td>
+    <td style="white-space: nowrap; text-align: right">45.78 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7568.21%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.65 M</td>
-    <td style="white-space: nowrap; text-align: right">150.40 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9853.73%</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
-    <td style="white-space: nowrap; text-align: right">230 ns</td>
+    <td style="white-space: nowrap; text-align: right">11.67 M</td>
+    <td style="white-space: nowrap; text-align: right">85.66 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1242.93%</td>
+    <td style="white-space: nowrap; text-align: right">80 ns</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.39 M</td>
-    <td style="white-space: nowrap; text-align: right">717.43 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;117.46%</td>
+    <td style="white-space: nowrap; text-align: right">1.40 M</td>
+    <td style="white-space: nowrap; text-align: right">715.49 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;104.30%</td>
     <td style="white-space: nowrap; text-align: right">710 ns</td>
-    <td style="white-space: nowrap; text-align: right">880 ns</td>
+    <td style="white-space: nowrap; text-align: right">850 ns</td>
   </tr>
 
 </table>
@@ -606,20 +606,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.80 M</td>
+    <td style="white-space: nowrap;text-align: right">21.84 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.65 M</td>
-    <td style="white-space: nowrap; text-align: right">3.13x</td>
+    <td style="white-space: nowrap; text-align: right">11.67 M</td>
+    <td style="white-space: nowrap; text-align: right">1.87x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.39 M</td>
-    <td style="white-space: nowrap; text-align: right">14.92x</td>
+    <td style="white-space: nowrap; text-align: right">1.40 M</td>
+    <td style="white-space: nowrap; text-align: right">15.63x</td>
   </tr>
 
 </table>
@@ -668,8 +668,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">33</td>
-    <td>11.0x</td>
+    <td style="white-space: nowrap">11</td>
+    <td>3.67x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -695,28 +695,28 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.98 M</td>
-    <td style="white-space: nowrap; text-align: right">47.66 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5221.48%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">22.26 M</td>
+    <td style="white-space: nowrap; text-align: right">44.93 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7785.27%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.58 M</td>
-    <td style="white-space: nowrap; text-align: right">152.07 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;9569.77%</td>
-    <td style="white-space: nowrap; text-align: right">140 ns</td>
-    <td style="white-space: nowrap; text-align: right">230 ns</td>
+    <td style="white-space: nowrap; text-align: right">11.47 M</td>
+    <td style="white-space: nowrap; text-align: right">87.15 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;626.38%</td>
+    <td style="white-space: nowrap; text-align: right">80 ns</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.16 M</td>
-    <td style="white-space: nowrap; text-align: right">865.15 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;66.23%</td>
-    <td style="white-space: nowrap; text-align: right">860 ns</td>
+    <td style="white-space: nowrap; text-align: right">1.22 M</td>
+    <td style="white-space: nowrap; text-align: right">822.15 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;59.44%</td>
+    <td style="white-space: nowrap; text-align: right">800 ns</td>
     <td style="white-space: nowrap; text-align: right">1060 ns</td>
   </tr>
 
@@ -732,20 +732,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.98 M</td>
+    <td style="white-space: nowrap;text-align: right">22.26 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">6.58 M</td>
-    <td style="white-space: nowrap; text-align: right">3.19x</td>
+    <td style="white-space: nowrap; text-align: right">11.47 M</td>
+    <td style="white-space: nowrap; text-align: right">1.94x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.16 M</td>
-    <td style="white-space: nowrap; text-align: right">18.15x</td>
+    <td style="white-space: nowrap; text-align: right">1.22 M</td>
+    <td style="white-space: nowrap; text-align: right">18.3x</td>
   </tr>
 
 </table>
@@ -794,8 +794,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">33</td>
-    <td>11.0x</td>
+    <td style="white-space: nowrap">11</td>
+    <td>3.67x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -820,30 +820,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.30 M</td>
-    <td style="white-space: nowrap; text-align: right">49.25 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6791.12%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">24.62 M</td>
+    <td style="white-space: nowrap; text-align: right">40.61 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2821.77%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.11 M</td>
-    <td style="white-space: nowrap; text-align: right">49.73 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6475.56%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.22 M</td>
+    <td style="white-space: nowrap; text-align: right">45.01 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7777.10%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.06 M</td>
-    <td style="white-space: nowrap; text-align: right">940.56 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;99.21%</td>
+    <td style="white-space: nowrap; text-align: right">1.07 M</td>
+    <td style="white-space: nowrap; text-align: right">938.22 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;89.05%</td>
     <td style="white-space: nowrap; text-align: right">910 ns</td>
-    <td style="white-space: nowrap; text-align: right">1120 ns</td>
+    <td style="white-space: nowrap; text-align: right">1100 ns</td>
   </tr>
 
 </table>
@@ -857,21 +857,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.30 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">24.62 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">20.11 M</td>
-    <td style="white-space: nowrap; text-align: right">1.01x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.22 M</td>
+    <td style="white-space: nowrap; text-align: right">1.11x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.06 M</td>
-    <td style="white-space: nowrap; text-align: right">19.1x</td>
+    <td style="white-space: nowrap; text-align: right">1.07 M</td>
+    <td style="white-space: nowrap; text-align: right">23.1x</td>
   </tr>
 
 </table>
@@ -887,12 +887,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -914,14 +914,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -946,30 +946,30 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">24.66 M</td>
+    <td style="white-space: nowrap; text-align: right">40.55 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2359.22%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.78 M</td>
-    <td style="white-space: nowrap; text-align: right">45.92 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7167.30%</td>
+    <td style="white-space: nowrap; text-align: right">22.60 M</td>
+    <td style="white-space: nowrap; text-align: right">44.25 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4692.79%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.53 M</td>
-    <td style="white-space: nowrap; text-align: right">51.19 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5984.12%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.06 M</td>
-    <td style="white-space: nowrap; text-align: right">946.25 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;75.42%</td>
-    <td style="white-space: nowrap; text-align: right">940 ns</td>
-    <td style="white-space: nowrap; text-align: right">1160 ns</td>
+    <td style="white-space: nowrap; text-align: right">1.00 M</td>
+    <td style="white-space: nowrap; text-align: right">996.21 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;58.87%</td>
+    <td style="white-space: nowrap; text-align: right">1040 ns</td>
+    <td style="white-space: nowrap; text-align: right">1170 ns</td>
   </tr>
 
 </table>
@@ -983,21 +983,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.78 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">24.66 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.53 M</td>
-    <td style="white-space: nowrap; text-align: right">1.11x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.60 M</td>
+    <td style="white-space: nowrap; text-align: right">1.09x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.06 M</td>
-    <td style="white-space: nowrap; text-align: right">20.61x</td>
+    <td style="white-space: nowrap; text-align: right">1.00 M</td>
+    <td style="white-space: nowrap; text-align: right">24.57x</td>
   </tr>
 
 </table>
@@ -1013,12 +1013,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1040,14 +1040,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -1072,29 +1072,29 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.27 M</td>
+    <td style="white-space: nowrap; text-align: right">39.58 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2184.71%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">21.99 M</td>
-    <td style="white-space: nowrap; text-align: right">45.48 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6891.13%</td>
+    <td style="white-space: nowrap; text-align: right">22.52 M</td>
+    <td style="white-space: nowrap; text-align: right">44.40 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6695.47%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.15 M</td>
-    <td style="white-space: nowrap; text-align: right">52.22 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5690.05%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.05 M</td>
-    <td style="white-space: nowrap; text-align: right">954.39 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;56.36%</td>
-    <td style="white-space: nowrap; text-align: right">940 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.93 M</td>
+    <td style="white-space: nowrap; text-align: right">1070.34 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;61.97%</td>
+    <td style="white-space: nowrap; text-align: right">1050 ns</td>
     <td style="white-space: nowrap; text-align: right">1170 ns</td>
   </tr>
 
@@ -1109,21 +1109,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">21.99 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.27 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">19.15 M</td>
-    <td style="white-space: nowrap; text-align: right">1.15x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.52 M</td>
+    <td style="white-space: nowrap; text-align: right">1.12x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.05 M</td>
-    <td style="white-space: nowrap; text-align: right">20.98x</td>
+    <td style="white-space: nowrap; text-align: right">0.93 M</td>
+    <td style="white-space: nowrap; text-align: right">27.04x</td>
   </tr>
 
 </table>
@@ -1139,12 +1139,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1166,14 +1166,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>

--- a/benchmark/result_10000.md
+++ b/benchmark/result_10000.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2024-06-19 23:06:35.733718Z UTC
+Benchmark run from 2024-06-20 13:35:13.652401Z UTC
 
 ## System
 
@@ -64,28 +64,28 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">26.10 M</td>
+    <td style="white-space: nowrap; text-align: right">38.31 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;771.01%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">24.19 M</td>
-    <td style="white-space: nowrap; text-align: right">41.34 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;10526.10%</td>
+    <td style="white-space: nowrap; text-align: right">26.10 M</td>
+    <td style="white-space: nowrap; text-align: right">38.32 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;644.90%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.47 M</td>
-    <td style="white-space: nowrap; text-align: right">51.35 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5317.13%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.80 M</td>
-    <td style="white-space: nowrap; text-align: right">53.19 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;11742.84%</td>
+    <td style="white-space: nowrap; text-align: right">20.52 M</td>
+    <td style="white-space: nowrap; text-align: right">48.74 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;802.63%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
@@ -101,21 +101,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">24.19 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">26.10 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.47 M</td>
-    <td style="white-space: nowrap; text-align: right">1.24x</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">26.10 M</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.80 M</td>
-    <td style="white-space: nowrap; text-align: right">1.29x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.52 M</td>
+    <td style="white-space: nowrap; text-align: right">1.27x</td>
   </tr>
 
 </table>
@@ -131,17 +131,17 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -158,19 +158,19 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
+    <td>&nbsp;</td>
+  </tr>
+    <tr>
     <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">4</td>
-    <td>&nbsp;</td>
+    <td>1.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">3</td>
-    <td>0.75x</td>
-  </tr>
-    <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.25x</td>
+    <td>1.0x</td>
   </tr>
 </table>
 
@@ -191,29 +191,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.33 M</td>
-    <td style="white-space: nowrap; text-align: right">51.73 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7414.89%</td>
+    <td style="white-space: nowrap; text-align: right">20.61 M</td>
+    <td style="white-space: nowrap; text-align: right">48.53 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;732.95%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">5.71 M</td>
-    <td style="white-space: nowrap; text-align: right">175.15 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;10033.37%</td>
-    <td style="white-space: nowrap; text-align: right">160 ns</td>
-    <td style="white-space: nowrap; text-align: right">270 ns</td>
+    <td style="white-space: nowrap; text-align: right">11.09 M</td>
+    <td style="white-space: nowrap; text-align: right">90.19 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;612.66%</td>
+    <td style="white-space: nowrap; text-align: right">90 ns</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.04 M</td>
-    <td style="white-space: nowrap; text-align: right">959.57 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;598.98%</td>
-    <td style="white-space: nowrap; text-align: right">950 ns</td>
-    <td style="white-space: nowrap; text-align: right">1030 ns</td>
+    <td style="white-space: nowrap; text-align: right">1.06 M</td>
+    <td style="white-space: nowrap; text-align: right">940.58 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;91.25%</td>
+    <td style="white-space: nowrap; text-align: right">930 ns</td>
+    <td style="white-space: nowrap; text-align: right">960 ns</td>
   </tr>
 
 </table>
@@ -228,20 +228,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.33 M</td>
+    <td style="white-space: nowrap;text-align: right">20.61 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">5.71 M</td>
-    <td style="white-space: nowrap; text-align: right">3.39x</td>
+    <td style="white-space: nowrap; text-align: right">11.09 M</td>
+    <td style="white-space: nowrap; text-align: right">1.86x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">1.04 M</td>
-    <td style="white-space: nowrap; text-align: right">18.55x</td>
+    <td style="white-space: nowrap; text-align: right">1.06 M</td>
+    <td style="white-space: nowrap; text-align: right">19.38x</td>
   </tr>
 
 </table>
@@ -290,8 +290,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">39</td>
-    <td>13.0x</td>
+    <td style="white-space: nowrap">13</td>
+    <td>4.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -317,29 +317,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.35 M</td>
-    <td style="white-space: nowrap; text-align: right">51.69 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7572.47%</td>
+    <td style="white-space: nowrap; text-align: right">20.52 M</td>
+    <td style="white-space: nowrap; text-align: right">48.73 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;785.14%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">19.69 M</td>
+    <td style="white-space: nowrap; text-align: right">50.79 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;833.80%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.18 M</td>
-    <td style="white-space: nowrap; text-align: right">75.87 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;21295.19%</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-    <td style="white-space: nowrap; text-align: right">90 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap; text-align: right">0.44 M</td>
-    <td style="white-space: nowrap; text-align: right">2291.05 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;32.39%</td>
-    <td style="white-space: nowrap; text-align: right">2270 ns</td>
-    <td style="white-space: nowrap; text-align: right">2720 ns</td>
+    <td style="white-space: nowrap; text-align: right">2257.38 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;65.04%</td>
+    <td style="white-space: nowrap; text-align: right">2230 ns</td>
+    <td style="white-space: nowrap; text-align: right">2620 ns</td>
   </tr>
 
 </table>
@@ -354,20 +354,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.35 M</td>
+    <td style="white-space: nowrap;text-align: right">20.52 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.18 M</td>
-    <td style="white-space: nowrap; text-align: right">1.47x</td>
+    <td style="white-space: nowrap; text-align: right">19.69 M</td>
+    <td style="white-space: nowrap; text-align: right">1.04x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap; text-align: right">0.44 M</td>
-    <td style="white-space: nowrap; text-align: right">44.32x</td>
+    <td style="white-space: nowrap; text-align: right">46.33x</td>
   </tr>
 
 </table>
@@ -416,8 +416,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">12</td>
-    <td>4.0x</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -442,30 +442,30 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.70 M</td>
+    <td style="white-space: nowrap; text-align: right">46.09 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1217.80%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.37 M</td>
-    <td style="white-space: nowrap; text-align: right">54.42 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7390.50%</td>
+    <td style="white-space: nowrap; text-align: right">19.11 M</td>
+    <td style="white-space: nowrap; text-align: right">52.34 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;731.87%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">15.43 M</td>
-    <td style="white-space: nowrap; text-align: right">64.81 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;24134.46%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">80 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.22 M</td>
-    <td style="white-space: nowrap; text-align: right">4509.99 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5.60%</td>
-    <td style="white-space: nowrap; text-align: right">4480 ns</td>
-    <td style="white-space: nowrap; text-align: right">4950 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.23 M</td>
+    <td style="white-space: nowrap; text-align: right">4435.21 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4.99%</td>
+    <td style="white-space: nowrap; text-align: right">4400 ns</td>
+    <td style="white-space: nowrap; text-align: right">4811 ns</td>
   </tr>
 
 </table>
@@ -479,21 +479,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">18.37 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">21.70 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">15.43 M</td>
-    <td style="white-space: nowrap; text-align: right">1.19x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">19.11 M</td>
+    <td style="white-space: nowrap; text-align: right">1.14x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.22 M</td>
-    <td style="white-space: nowrap; text-align: right">82.87x</td>
+    <td style="white-space: nowrap; text-align: right">0.23 M</td>
+    <td style="white-space: nowrap; text-align: right">96.24x</td>
   </tr>
 
 </table>
@@ -509,12 +509,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -536,14 +536,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">9</td>
-    <td>3.0x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -569,29 +569,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.40 M</td>
-    <td style="white-space: nowrap; text-align: right">51.54 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7581.48%</td>
+    <td style="white-space: nowrap; text-align: right">20.60 M</td>
+    <td style="white-space: nowrap; text-align: right">48.54 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;801.75%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">5.09 M</td>
-    <td style="white-space: nowrap; text-align: right">196.36 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;3423.80%</td>
-    <td style="white-space: nowrap; text-align: right">180 ns</td>
-    <td style="white-space: nowrap; text-align: right">300 ns</td>
+    <td style="white-space: nowrap; text-align: right">9.72 M</td>
+    <td style="white-space: nowrap; text-align: right">102.84 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;472.21%</td>
+    <td style="white-space: nowrap; text-align: right">100 ns</td>
+    <td style="white-space: nowrap; text-align: right">130 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.148 M</td>
-    <td style="white-space: nowrap; text-align: right">6772.17 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;4.91%</td>
-    <td style="white-space: nowrap; text-align: right">6710 ns</td>
-    <td style="white-space: nowrap; text-align: right">7970 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.151 M</td>
+    <td style="white-space: nowrap; text-align: right">6616.81 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;3.92%</td>
+    <td style="white-space: nowrap; text-align: right">6560 ns</td>
+    <td style="white-space: nowrap; text-align: right">7060 ns</td>
   </tr>
 
 </table>
@@ -606,20 +606,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.40 M</td>
+    <td style="white-space: nowrap;text-align: right">20.60 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">5.09 M</td>
-    <td style="white-space: nowrap; text-align: right">3.81x</td>
+    <td style="white-space: nowrap; text-align: right">9.72 M</td>
+    <td style="white-space: nowrap; text-align: right">2.12x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.148 M</td>
-    <td style="white-space: nowrap; text-align: right">131.39x</td>
+    <td style="white-space: nowrap; text-align: right">0.151 M</td>
+    <td style="white-space: nowrap; text-align: right">136.32x</td>
   </tr>
 
 </table>
@@ -668,8 +668,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">45</td>
-    <td>15.0x</td>
+    <td style="white-space: nowrap">15</td>
+    <td>5.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -695,29 +695,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.40 M</td>
-    <td style="white-space: nowrap; text-align: right">51.55 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7539.65%</td>
+    <td style="white-space: nowrap; text-align: right">20.57 M</td>
+    <td style="white-space: nowrap; text-align: right">48.62 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;934.78%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.85 M</td>
-    <td style="white-space: nowrap; text-align: right">206.37 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;3344.18%</td>
-    <td style="white-space: nowrap; text-align: right">190 ns</td>
-    <td style="white-space: nowrap; text-align: right">310 ns</td>
+    <td style="white-space: nowrap; text-align: right">9.11 M</td>
+    <td style="white-space: nowrap; text-align: right">109.73 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;456.43%</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.123 M</td>
-    <td style="white-space: nowrap; text-align: right">8114.33 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.06%</td>
-    <td style="white-space: nowrap; text-align: right">8030 ns</td>
-    <td style="white-space: nowrap; text-align: right">10140 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.132 M</td>
+    <td style="white-space: nowrap; text-align: right">7588.35 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6.00%</td>
+    <td style="white-space: nowrap; text-align: right">7530 ns</td>
+    <td style="white-space: nowrap; text-align: right">8430 ns</td>
   </tr>
 
 </table>
@@ -732,20 +732,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.40 M</td>
+    <td style="white-space: nowrap;text-align: right">20.57 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.85 M</td>
-    <td style="white-space: nowrap; text-align: right">4.0x</td>
+    <td style="white-space: nowrap; text-align: right">9.11 M</td>
+    <td style="white-space: nowrap; text-align: right">2.26x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.123 M</td>
-    <td style="white-space: nowrap; text-align: right">157.4x</td>
+    <td style="white-space: nowrap; text-align: right">0.132 M</td>
+    <td style="white-space: nowrap; text-align: right">156.09x</td>
   </tr>
 
 </table>
@@ -794,8 +794,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">48</td>
-    <td>16.0x</td>
+    <td style="white-space: nowrap">16</td>
+    <td>5.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -820,30 +820,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.34 M</td>
-    <td style="white-space: nowrap; text-align: right">51.70 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7705.26%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.09 M</td>
+    <td style="white-space: nowrap; text-align: right">39.85 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1241.26%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.13 M</td>
-    <td style="white-space: nowrap; text-align: right">55.17 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16752.73%</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.50 M</td>
+    <td style="white-space: nowrap; text-align: right">48.78 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;849.37%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0972 M</td>
-    <td style="white-space: nowrap; text-align: right">10283.23 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.55%</td>
-    <td style="white-space: nowrap; text-align: right">9990 ns</td>
-    <td style="white-space: nowrap; text-align: right">12950 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.116 M</td>
+    <td style="white-space: nowrap; text-align: right">8612.95 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6.24%</td>
+    <td style="white-space: nowrap; text-align: right">8480 ns</td>
+    <td style="white-space: nowrap; text-align: right">10374.96 ns</td>
   </tr>
 
 </table>
@@ -857,21 +857,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.34 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.09 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.13 M</td>
-    <td style="white-space: nowrap; text-align: right">1.07x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.50 M</td>
+    <td style="white-space: nowrap; text-align: right">1.22x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0972 M</td>
-    <td style="white-space: nowrap; text-align: right">198.9x</td>
+    <td style="white-space: nowrap; text-align: right">0.116 M</td>
+    <td style="white-space: nowrap; text-align: right">216.13x</td>
   </tr>
 
 </table>
@@ -887,12 +887,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -914,14 +914,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -946,30 +946,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.39 M</td>
-    <td style="white-space: nowrap; text-align: right">49.05 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8203.56%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">23.91 M</td>
+    <td style="white-space: nowrap; text-align: right">41.82 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1429.23%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.60 M</td>
-    <td style="white-space: nowrap; text-align: right">53.75 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;11942.73%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.00 M</td>
+    <td style="white-space: nowrap; text-align: right">45.45 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;857.32%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0975 M</td>
-    <td style="white-space: nowrap; text-align: right">10257.07 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.04%</td>
-    <td style="white-space: nowrap; text-align: right">10160 ns</td>
-    <td style="white-space: nowrap; text-align: right">13250 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.100 M</td>
+    <td style="white-space: nowrap; text-align: right">9956.02 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5.98%</td>
+    <td style="white-space: nowrap; text-align: right">9800 ns</td>
+    <td style="white-space: nowrap; text-align: right">12001 ns</td>
   </tr>
 
 </table>
@@ -983,21 +983,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.39 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">23.91 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.60 M</td>
-    <td style="white-space: nowrap; text-align: right">1.1x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.00 M</td>
+    <td style="white-space: nowrap; text-align: right">1.09x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0975 M</td>
-    <td style="white-space: nowrap; text-align: right">209.1x</td>
+    <td style="white-space: nowrap; text-align: right">0.100 M</td>
+    <td style="white-space: nowrap; text-align: right">238.07x</td>
   </tr>
 
 </table>
@@ -1013,12 +1013,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1040,14 +1040,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -1072,30 +1072,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.53 M</td>
-    <td style="white-space: nowrap; text-align: right">48.71 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5907.58%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.62 M</td>
+    <td style="white-space: nowrap; text-align: right">39.04 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1365.21%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.61 M</td>
+    <td style="white-space: nowrap; text-align: right">44.22 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;492.47%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.90 M</td>
-    <td style="white-space: nowrap; text-align: right">55.85 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16113.30%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0981 M</td>
-    <td style="white-space: nowrap; text-align: right">10190.76 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;14.34%</td>
-    <td style="white-space: nowrap; text-align: right">9990 ns</td>
-    <td style="white-space: nowrap; text-align: right">12900 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.100 M</td>
+    <td style="white-space: nowrap; text-align: right">9959.17 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4.64%</td>
+    <td style="white-space: nowrap; text-align: right">9800 ns</td>
+    <td style="white-space: nowrap; text-align: right">11910 ns</td>
   </tr>
 
 </table>
@@ -1109,21 +1109,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.53 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.62 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">17.90 M</td>
-    <td style="white-space: nowrap; text-align: right">1.15x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">22.61 M</td>
+    <td style="white-space: nowrap; text-align: right">1.13x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0981 M</td>
-    <td style="white-space: nowrap; text-align: right">209.21x</td>
+    <td style="white-space: nowrap; text-align: right">0.100 M</td>
+    <td style="white-space: nowrap; text-align: right">255.13x</td>
   </tr>
 
 </table>
@@ -1139,12 +1139,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1166,14 +1166,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>

--- a/benchmark/result_100000.md
+++ b/benchmark/result_100000.md
@@ -1,6 +1,6 @@
 Benchmark
 
-Benchmark run from 2024-06-19 23:13:28.321225Z UTC
+Benchmark run from 2024-06-20 13:41:25.385612Z UTC
 
 ## System
 
@@ -64,28 +64,28 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">23.99 M</td>
-    <td style="white-space: nowrap; text-align: right">41.68 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;8315.54%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">26.26 M</td>
+    <td style="white-space: nowrap; text-align: right">38.08 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1592.70%</td>
     <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.95 M</td>
-    <td style="white-space: nowrap; text-align: right">52.78 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16381.18%</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.53 M</td>
+    <td style="white-space: nowrap; text-align: right">39.17 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5843.60%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.74 M</td>
-    <td style="white-space: nowrap; text-align: right">53.35 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5272.36%</td>
+    <td style="white-space: nowrap; text-align: right">19.50 M</td>
+    <td style="white-space: nowrap; text-align: right">51.28 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6458.61%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
@@ -101,21 +101,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap;text-align: right">23.99 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">26.26 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.95 M</td>
-    <td style="white-space: nowrap; text-align: right">1.27x</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.53 M</td>
+    <td style="white-space: nowrap; text-align: right">1.03x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.74 M</td>
-    <td style="white-space: nowrap; text-align: right">1.28x</td>
+    <td style="white-space: nowrap; text-align: right">19.50 M</td>
+    <td style="white-space: nowrap; text-align: right">1.35x</td>
   </tr>
 
 </table>
@@ -131,12 +131,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Enum.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -158,19 +158,19 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap">4</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.25x</td>
+    <td style="white-space: nowrap">Enum.member?</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">3</td>
-    <td>0.75x</td>
+    <td>1.0x</td>
   </tr>
 </table>
 
@@ -191,29 +191,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.86 M</td>
-    <td style="white-space: nowrap; text-align: right">53.02 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5845.26%</td>
+    <td style="white-space: nowrap; text-align: right">19.73 M</td>
+    <td style="white-space: nowrap; text-align: right">50.68 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6703.94%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.26 M</td>
-    <td style="white-space: nowrap; text-align: right">234.66 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;2017.16%</td>
-    <td style="white-space: nowrap; text-align: right">220 ns</td>
-    <td style="white-space: nowrap; text-align: right">340 ns</td>
+    <td style="white-space: nowrap; text-align: right">8.82 M</td>
+    <td style="white-space: nowrap; text-align: right">113.31 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;427.12%</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
+    <td style="white-space: nowrap; text-align: right">140 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.111 M</td>
-    <td style="white-space: nowrap; text-align: right">8983.10 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.07%</td>
-    <td style="white-space: nowrap; text-align: right">8920 ns</td>
-    <td style="white-space: nowrap; text-align: right">10540 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.114 M</td>
+    <td style="white-space: nowrap; text-align: right">8797.10 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5.08%</td>
+    <td style="white-space: nowrap; text-align: right">8730 ns</td>
+    <td style="white-space: nowrap; text-align: right">9400 ns</td>
   </tr>
 
 </table>
@@ -228,20 +228,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">18.86 M</td>
+    <td style="white-space: nowrap;text-align: right">19.73 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.26 M</td>
-    <td style="white-space: nowrap; text-align: right">4.43x</td>
+    <td style="white-space: nowrap; text-align: right">8.82 M</td>
+    <td style="white-space: nowrap; text-align: right">2.24x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.111 M</td>
-    <td style="white-space: nowrap; text-align: right">169.42x</td>
+    <td style="white-space: nowrap; text-align: right">0.114 M</td>
+    <td style="white-space: nowrap; text-align: right">173.57x</td>
   </tr>
 
 </table>
@@ -290,8 +290,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">54</td>
-    <td>18.0x</td>
+    <td style="white-space: nowrap">18</td>
+    <td>6.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -317,29 +317,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.85 M</td>
-    <td style="white-space: nowrap; text-align: right">53.04 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5292.14%</td>
+    <td style="white-space: nowrap; text-align: right">19.85 M</td>
+    <td style="white-space: nowrap; text-align: right">50.37 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;3907.72%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.13 M</td>
-    <td style="white-space: nowrap; text-align: right">76.19 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;23049.36%</td>
+    <td style="white-space: nowrap; text-align: right">19.66 M</td>
+    <td style="white-space: nowrap; text-align: right">50.86 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;842.10%</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
-    <td style="white-space: nowrap; text-align: right">100 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0446 M</td>
-    <td style="white-space: nowrap; text-align: right">22410.21 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;3.46%</td>
-    <td style="white-space: nowrap; text-align: right">22250 ns</td>
-    <td style="white-space: nowrap; text-align: right">26060 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0456 M</td>
+    <td style="white-space: nowrap; text-align: right">21930.79 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;3.13%</td>
+    <td style="white-space: nowrap; text-align: right">21731 ns</td>
+    <td style="white-space: nowrap; text-align: right">24590 ns</td>
   </tr>
 
 </table>
@@ -354,20 +354,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">18.85 M</td>
+    <td style="white-space: nowrap;text-align: right">19.85 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">13.13 M</td>
-    <td style="white-space: nowrap; text-align: right">1.44x</td>
+    <td style="white-space: nowrap; text-align: right">19.66 M</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0446 M</td>
-    <td style="white-space: nowrap; text-align: right">422.54x</td>
+    <td style="white-space: nowrap; text-align: right">0.0456 M</td>
+    <td style="white-space: nowrap; text-align: right">435.37x</td>
   </tr>
 
 </table>
@@ -416,8 +416,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">12</td>
-    <td>4.0x</td>
+    <td style="white-space: nowrap">4</td>
+    <td>1.33x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -442,30 +442,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.87 M</td>
-    <td style="white-space: nowrap; text-align: right">50.32 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5558.61%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">21.61 M</td>
+    <td style="white-space: nowrap; text-align: right">46.28 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1365.92%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">15.71 M</td>
-    <td style="white-space: nowrap; text-align: right">63.67 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;31345.16%</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.74 M</td>
+    <td style="white-space: nowrap; text-align: right">48.22 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6790.86%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">80 ns</td>
+    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0222 M</td>
-    <td style="white-space: nowrap; text-align: right">45054.18 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;2.63%</td>
-    <td style="white-space: nowrap; text-align: right">44740 ns</td>
-    <td style="white-space: nowrap; text-align: right">49940 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0228 M</td>
+    <td style="white-space: nowrap; text-align: right">43788.58 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2.56%</td>
+    <td style="white-space: nowrap; text-align: right">43470 ns</td>
+    <td style="white-space: nowrap; text-align: right">47070 ns</td>
   </tr>
 
 </table>
@@ -479,21 +479,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.87 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">21.61 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">15.71 M</td>
-    <td style="white-space: nowrap; text-align: right">1.27x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.74 M</td>
+    <td style="white-space: nowrap; text-align: right">1.04x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0222 M</td>
-    <td style="white-space: nowrap; text-align: right">895.31x</td>
+    <td style="white-space: nowrap; text-align: right">0.0228 M</td>
+    <td style="white-space: nowrap; text-align: right">946.11x</td>
   </tr>
 
 </table>
@@ -509,12 +509,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -536,14 +536,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">9</td>
-    <td>3.0x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -569,29 +569,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">19.06 M</td>
-    <td style="white-space: nowrap; text-align: right">52.47 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5349.97%</td>
+    <td style="white-space: nowrap; text-align: right">19.78 M</td>
+    <td style="white-space: nowrap; text-align: right">50.56 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4428.82%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.18 M</td>
-    <td style="white-space: nowrap; text-align: right">238.98 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;2018.17%</td>
-    <td style="white-space: nowrap; text-align: right">230 ns</td>
-    <td style="white-space: nowrap; text-align: right">340 ns</td>
+    <td style="white-space: nowrap; text-align: right">8.55 M</td>
+    <td style="white-space: nowrap; text-align: right">116.89 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;607.83%</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
+    <td style="white-space: nowrap; text-align: right">150 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0154 M</td>
-    <td style="white-space: nowrap; text-align: right">64960.44 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;7.49%</td>
-    <td style="white-space: nowrap; text-align: right">64231 ns</td>
-    <td style="white-space: nowrap; text-align: right">76173.85 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0161 M</td>
+    <td style="white-space: nowrap; text-align: right">62264.77 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2.65%</td>
+    <td style="white-space: nowrap; text-align: right">62010 ns</td>
+    <td style="white-space: nowrap; text-align: right">66393.70 ns</td>
   </tr>
 
 </table>
@@ -606,20 +606,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">19.06 M</td>
+    <td style="white-space: nowrap;text-align: right">19.78 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.18 M</td>
-    <td style="white-space: nowrap; text-align: right">4.55x</td>
+    <td style="white-space: nowrap; text-align: right">8.55 M</td>
+    <td style="white-space: nowrap; text-align: right">2.31x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0154 M</td>
-    <td style="white-space: nowrap; text-align: right">1238.16x</td>
+    <td style="white-space: nowrap; text-align: right">0.0161 M</td>
+    <td style="white-space: nowrap; text-align: right">1231.56x</td>
   </tr>
 
 </table>
@@ -668,8 +668,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">54</td>
-    <td>18.0x</td>
+    <td style="white-space: nowrap">18</td>
+    <td>6.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -695,29 +695,29 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.83 M</td>
-    <td style="white-space: nowrap; text-align: right">53.12 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5191.28%</td>
+    <td style="white-space: nowrap; text-align: right">19.43 M</td>
+    <td style="white-space: nowrap; text-align: right">51.48 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6227.41%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.66 M</td>
-    <td style="white-space: nowrap; text-align: right">214.47 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;1826.30%</td>
-    <td style="white-space: nowrap; text-align: right">200 ns</td>
-    <td style="white-space: nowrap; text-align: right">320 ns</td>
+    <td style="white-space: nowrap; text-align: right">9.02 M</td>
+    <td style="white-space: nowrap; text-align: right">110.83 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;643.29%</td>
+    <td style="white-space: nowrap; text-align: right">110 ns</td>
+    <td style="white-space: nowrap; text-align: right">140 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0124 M</td>
-    <td style="white-space: nowrap; text-align: right">80849.80 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;1.94%</td>
-    <td style="white-space: nowrap; text-align: right">80421 ns</td>
-    <td style="white-space: nowrap; text-align: right">86301 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0127 M</td>
+    <td style="white-space: nowrap; text-align: right">78669.32 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2.00%</td>
+    <td style="white-space: nowrap; text-align: right">78631 ns</td>
+    <td style="white-space: nowrap; text-align: right">82432.62 ns</td>
   </tr>
 
 </table>
@@ -732,20 +732,20 @@ Run Time Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">18.83 M</td>
+    <td style="white-space: nowrap;text-align: right">19.43 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">4.66 M</td>
-    <td style="white-space: nowrap; text-align: right">4.04x</td>
+    <td style="white-space: nowrap; text-align: right">9.02 M</td>
+    <td style="white-space: nowrap; text-align: right">2.15x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0124 M</td>
-    <td style="white-space: nowrap; text-align: right">1522.02x</td>
+    <td style="white-space: nowrap; text-align: right">0.0127 M</td>
+    <td style="white-space: nowrap; text-align: right">1528.26x</td>
   </tr>
 
 </table>
@@ -794,8 +794,8 @@ Reduction Count
   </tr>
     <tr>
     <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">51</td>
-    <td>17.0x</td>
+    <td style="white-space: nowrap">17</td>
+    <td>5.67x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -820,30 +820,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">18.90 M</td>
-    <td style="white-space: nowrap; text-align: right">52.90 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5259.32%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.03 M</td>
+    <td style="white-space: nowrap; text-align: right">39.95 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1595.47%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.78 M</td>
-    <td style="white-space: nowrap; text-align: right">53.25 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16731.30%</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">19.40 M</td>
+    <td style="white-space: nowrap; text-align: right">51.53 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7530.67%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">70 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0106 M</td>
-    <td style="white-space: nowrap; text-align: right">94411.09 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;6.15%</td>
-    <td style="white-space: nowrap; text-align: right">90391 ns</td>
-    <td style="white-space: nowrap; text-align: right">106201 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0114 M</td>
+    <td style="white-space: nowrap; text-align: right">87705.38 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1.20%</td>
+    <td style="white-space: nowrap; text-align: right">87470 ns</td>
+    <td style="white-space: nowrap; text-align: right">90990 ns</td>
   </tr>
 
 </table>
@@ -857,21 +857,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">18.90 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.03 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.78 M</td>
-    <td style="white-space: nowrap; text-align: right">1.01x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">19.40 M</td>
+    <td style="white-space: nowrap; text-align: right">1.29x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.0106 M</td>
-    <td style="white-space: nowrap; text-align: right">1784.72x</td>
+    <td style="white-space: nowrap; text-align: right">0.0114 M</td>
+    <td style="white-space: nowrap; text-align: right">2195.25x</td>
   </tr>
 
 </table>
@@ -887,12 +887,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -914,14 +914,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -946,30 +946,30 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">24.13 M</td>
+    <td style="white-space: nowrap; text-align: right">41.43 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1418.16%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
+    <td style="white-space: nowrap; text-align: right">50 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.14 M</td>
-    <td style="white-space: nowrap; text-align: right">49.66 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5825.04%</td>
+    <td style="white-space: nowrap; text-align: right">20.99 M</td>
+    <td style="white-space: nowrap; text-align: right">47.64 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6877.86%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.74 M</td>
-    <td style="white-space: nowrap; text-align: right">53.36 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16867.36%</td>
-    <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">70 ns</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.00993 M</td>
-    <td style="white-space: nowrap; text-align: right">100687.72 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;1.63%</td>
-    <td style="white-space: nowrap; text-align: right">100201 ns</td>
-    <td style="white-space: nowrap; text-align: right">106281 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0102 M</td>
+    <td style="white-space: nowrap; text-align: right">98515.30 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1.25%</td>
+    <td style="white-space: nowrap; text-align: right">98200 ns</td>
+    <td style="white-space: nowrap; text-align: right">102180 ns</td>
   </tr>
 
 </table>
@@ -983,21 +983,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.14 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">24.13 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.74 M</td>
-    <td style="white-space: nowrap; text-align: right">1.07x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">20.99 M</td>
+    <td style="white-space: nowrap; text-align: right">1.15x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.00993 M</td>
-    <td style="white-space: nowrap; text-align: right">2027.62x</td>
+    <td style="white-space: nowrap; text-align: right">0.0102 M</td>
+    <td style="white-space: nowrap; text-align: right">2377.64x</td>
   </tr>
 
 </table>
@@ -1013,12 +1013,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1040,14 +1040,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">7</td>
-    <td>2.33x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>
@@ -1072,30 +1072,30 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap; text-align: right">20.20 M</td>
-    <td style="white-space: nowrap; text-align: right">49.51 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;5502.22%</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap; text-align: right">25.64 M</td>
+    <td style="white-space: nowrap; text-align: right">39.00 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1465.31%</td>
+    <td style="white-space: nowrap; text-align: right">40 ns</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
-    <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.50 M</td>
-    <td style="white-space: nowrap; text-align: right">54.04 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;16787.00%</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.31 M</td>
+    <td style="white-space: nowrap; text-align: right">46.93 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5905.14%</td>
     <td style="white-space: nowrap; text-align: right">50 ns</td>
     <td style="white-space: nowrap; text-align: right">60 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.00993 M</td>
-    <td style="white-space: nowrap; text-align: right">100721.09 ns</td>
-    <td style="white-space: nowrap; text-align: right">&plusmn;1.87%</td>
-    <td style="white-space: nowrap; text-align: right">100151 ns</td>
-    <td style="white-space: nowrap; text-align: right">107639.46 ns</td>
+    <td style="white-space: nowrap; text-align: right">0.0102 M</td>
+    <td style="white-space: nowrap; text-align: right">98455.57 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1.20%</td>
+    <td style="white-space: nowrap; text-align: right">98161 ns</td>
+    <td style="white-space: nowrap; text-align: right">101841 ns</td>
   </tr>
 
 </table>
@@ -1109,21 +1109,21 @@ Run Time Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
-    <td style="white-space: nowrap;text-align: right">20.20 M</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap;text-align: right">25.64 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap; text-align: right">18.50 M</td>
-    <td style="white-space: nowrap; text-align: right">1.09x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap; text-align: right">21.31 M</td>
+    <td style="white-space: nowrap; text-align: right">1.2x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Enum.member?</td>
-    <td style="white-space: nowrap; text-align: right">0.00993 M</td>
-    <td style="white-space: nowrap; text-align: right">2034.15x</td>
+    <td style="white-space: nowrap; text-align: right">0.0102 M</td>
+    <td style="white-space: nowrap; text-align: right">2524.54x</td>
   </tr>
 
 </table>
@@ -1139,12 +1139,12 @@ Memory Usage
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">0 B</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
+    <td style="white-space: nowrap">Map.get</td>
     <td style="white-space: nowrap">0 B</td>
     <td>1.0x</td>
   </tr>
@@ -1166,14 +1166,14 @@ Reduction Count
     <th style="text-align: right">Factor</th>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">Bsearch.member?</td>
     <td style="white-space: nowrap">3</td>
     <td>&nbsp;</td>
   </tr>
     <tr>
-    <td style="white-space: nowrap">Bsearch.member?</td>
-    <td style="white-space: nowrap">5</td>
-    <td>1.67x</td>
+    <td style="white-space: nowrap">Map.get</td>
+    <td style="white-space: nowrap">3</td>
+    <td>1.0x</td>
   </tr>
     <tr>
     <td style="white-space: nowrap">Enum.member?</td>

--- a/lib/bsearch.ex
+++ b/lib/bsearch.ex
@@ -2,7 +2,12 @@ defmodule Bsearch do
   @moduledoc """
   Module that contains the functions to use the Binary search.
 
-  Also
+  Initially, on the start of the project, this module was populated by maintanable and easily understandable code, but
+  that code clearly didn't cut it when the objective was performance, each new call to a new function that was there
+  only to make things DRI could result in a 30% or more performance loss in benchmarks.
+
+  So all functions in this module are thought out to be the most performant as possible guided by benchmarks, even if 
+  they became rather unmaintainable.
   """
 
   @doc """

--- a/lib/bsearch.ex
+++ b/lib/bsearch.ex
@@ -6,7 +6,7 @@ defmodule Bsearch do
   that code clearly didn't cut it when the objective was performance, each new call to a new function that was there
   only to make things DRI could result in a 30% or more performance loss in benchmarks.
 
-  So all functions in this module are thought out to be the most performant as possible guided by benchmarks, even if 
+  So all functions in this module are thought out to be the most performant as possible guided by benchmarks, even if
   they became rather unmaintainable.
   """
 

--- a/lib/bsearch.ex
+++ b/lib/bsearch.ex
@@ -1,6 +1,8 @@
 defmodule Bsearch do
   @moduledoc """
   Module that contains the functions to use the Binary search.
+
+  Also
   """
 
   @doc """
@@ -28,13 +30,16 @@ defmodule Bsearch do
   def member?({}, _), do: false
 
   def member?(tuple, value) when is_tuple(tuple) do
-    with :gt <- compare(value, elem(tuple, 0)),
+    with first_value <- elem(tuple, 0),
+         false <- value == first_value,
+         true <- value > first_value,
          high_index <- tuple_size(tuple) - 1,
-         :lt <- compare(value, elem(tuple, high_index)) do
+         last_value <- elem(tuple, high_index),
+         false <- value == last_value,
+         true <- value < last_value do
       _member(tuple, value, 1, high_index - 1)
     else
-      :eq -> true
-      _ -> false
+      value -> value
     end
   end
 
@@ -44,10 +49,10 @@ defmodule Bsearch do
     mid_index = div(low_index + high_index, 2)
     mid_value = elem(tuple, mid_index)
 
-    case compare(value, mid_value) do
-      :gt -> _member(tuple, value, mid_index + 1, high_index)
-      :lt -> _member(tuple, value, low_index, mid_index - 1)
-      _ -> true
+    cond do
+      value < mid_value -> _member(tuple, value, low_index, mid_index - 1)
+      value > mid_value -> _member(tuple, value, mid_index + 1, high_index)
+      value == mid_value -> true
     end
   end
 


### PR DESCRIPTION
Lower reduction count even more by stopping using the function `compare/2`, this brought a increse in performance from 1.1x to 2x, which is great!

- [x] lower stacktrace by stopping using compare/2
- [x] redo benchmarks
